### PR TITLE
Support mongodb 6.x.x and later

### DIFF
--- a/src/plugins/mongo/assets/templates/start.sh
+++ b/src/plugins/mongo/assets/templates/start.sh
@@ -43,7 +43,7 @@ elaspsed=0
 while [[ true ]]; do
   sleep 1
   elaspsed=$((elaspsed+1))
-  sudo docker exec mongodb mongo --eval \
+  sudo docker exec mongodb <%= mongoshCmd %> --eval \
     'try {var c = rs.config();} catch (e){} if (c && c.members[0].host === "127.0.0.1:27017") { c.members[0].host = "mongodb:27017"; rs.reconfig(c);  } else { rs.initiate({_id: "meteor", members: [{_id: 0, host: "mongodb:27017"}]}) }' \
     && exit 0
   

--- a/src/plugins/mongo/command-handlers.js
+++ b/src/plugins/mongo/command-handlers.js
@@ -57,6 +57,7 @@ export function setup(api) {
     dest: '/opt/mongodb/mongo-start-new.sh',
     vars: {
       mongoVersion: mongoConfig.version,
+      mongoshCmd: mongoConfig.version.split(".")[0] > 5 ? "mongosh" : "mongo",
       mongoDbDir: '/var/lib/mongodb'
     }
   });
@@ -116,7 +117,7 @@ export function shell(api) {
 
   const conn = new Client();
   conn.on('ready', () => {
-    conn.exec(`docker exec -it mongodb mongo ${dbName}`, {
+    conn.exec(`docker exec -it mongodb ${mongoConfig.version.split(".")[0] > 5 ? "mongosh" : "mongo" } ${dbName}`, {
       pty: true
     }, (err, stream) => {
       if (err) {
@@ -160,7 +161,7 @@ export async function status(api) {
     output: mongoStatus
   } = await api.runSSHCommand(
     server,
-    `docker exec mongodb mongo --eval ${mongoCommand} --quiet`
+    `docker exec mongodb ${mongoConfig.version.split(".")[0] > 5 ? "mongosh" : "mongo" } --eval ${mongoCommand} --quiet`
   );
 
   try {

--- a/src/plugins/mongo/command-handlers.js
+++ b/src/plugins/mongo/command-handlers.js
@@ -161,7 +161,7 @@ export async function status(api) {
     output: mongoStatus
   } = await api.runSSHCommand(
     server,
-    `docker exec mongodb ${mongoConfig.version.split(".")[0] > 5 ? "mongosh" : "mongo" } --eval ${mongoCommand} --quiet`
+    `docker exec mongodb ${config.mongo.version.split(".")[0] > 5 ? "mongosh" : "mongo" } --eval ${mongoCommand} --quiet`
   );
 
   try {

--- a/src/plugins/mongo/command-handlers.js
+++ b/src/plugins/mongo/command-handlers.js
@@ -117,7 +117,7 @@ export function shell(api) {
 
   const conn = new Client();
   conn.on('ready', () => {
-    conn.exec(`docker exec -it mongodb ${mongoConfig.version.split(".")[0] > 5 ? "mongosh" : "mongo" } ${dbName}`, {
+    conn.exec(`docker exec -it mongodb ${config.mongo.version.split(".")[0] > 5 ? "mongosh" : "mongo" } ${dbName}`, {
       pty: true
     }, (err, stream) => {
       if (err) {


### PR DESCRIPTION
Starting from mongodb version 6 the `mongo` shell is now called `mongosh`.

This pull request conditionally uses `mongosh` if a mongodb version 6 or later is configured or `mongo` for version 5 and previous.

Fixes #1341 